### PR TITLE
Delete 'id' value on INSERT statement to prevent autoincremental-id overlapping

### DIFF
--- a/sql/insert_admin_user.sql
+++ b/sql/insert_admin_user.sql
@@ -4,4 +4,4 @@ Run to insert an ADMIN user with the credentials
  - password 'password'
 Required to perform ADMIN operations
 */
-INSERT INTO "user" (id, email, role, password, created_at) VALUES (1, 'admin@example.com', 'ADMIN', '$2b$10$pDUcAEeRnYsBoLDxeimZhu6dvPVxWd9RLol2wRJI5nDKcmVAyrMkm', now())
+INSERT INTO "user" (email, role, password, created_at) VALUES ('admin@example.com', 'ADMIN', '$2b$10$pDUcAEeRnYsBoLDxeimZhu6dvPVxWd9RLol2wRJI5nDKcmVAyrMkm', now())

--- a/sql/insert_initial_movies.sql
+++ b/sql/insert_initial_movies.sql
@@ -2,9 +2,9 @@
 Run to insert initial movies data.
 It is not necessary to run it mandatorily.
 */
-INSERT INTO movie (id, created_at, title, director, opening_crawl, release_date) VALUES
-(1, now(), 'Star Wars Ep. I: The Phantom Menace', 'George Lucas', 'A long time ago in a galaxy far, far away....', '1999-05-19'),
-(2, now(), 'Star Wars Ep II: Attack of the Clones', 'George Lucas', 'A long time ago in a galaxy far, far away....', '2002-05-16'),
-(3, now(), 'Star Wars Ep III: Revenge of the Sith', 'George Lucas', 'A long time ago in a galaxy far, far away....', '2005-05-19'),
-(4, now(), 'Star Wars Ep IV: A New Hope', 'George Lucas', 'A long time ago in a galaxy far, far away....', '1977-05-25'),
-(5, now(), 'Star Wars Ep V: The Empire Strikes Back', 'Irvin Kershner', 'A long time ago in a galaxy far, far away....', '1980-05-21');
+INSERT INTO movie (created_at, title, director, opening_crawl, release_date) VALUES
+(now(), 'Star Wars Ep. I: The Phantom Menace', 'George Lucas', 'A long time ago in a galaxy far, far away....', '1999-05-19'),
+(now(), 'Star Wars Ep II: Attack of the Clones', 'George Lucas', 'A long time ago in a galaxy far, far away....', '2002-05-16'),
+(now(), 'Star Wars Ep III: Revenge of the Sith', 'George Lucas', 'A long time ago in a galaxy far, far away....', '2005-05-19'),
+(now(), 'Star Wars Ep IV: A New Hope', 'George Lucas', 'A long time ago in a galaxy far, far away....', '1977-05-25'),
+(now(), 'Star Wars Ep V: The Empire Strikes Back', 'Irvin Kershner', 'A long time ago in a galaxy far, far away....', '1980-05-21');


### PR DESCRIPTION
# Summary

- Delete 'id' value on INSERT statement to prevent autoincremental-id overlapping